### PR TITLE
Rum now observes two chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,9 +480,11 @@ dependencies = [
 name = "mosaic"
 version = "0.1.0"
 dependencies = [
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "web3 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 authors = ["Martin Schenck <martin@ost.com>"]
 
 [dependencies]
+futures = "^0.1.25"
 log = "^0.4.3"
 rpassword = "^2.0.0"
 simple_logger = "^0.5.0"
+tokio-core = "^0.1.17"
 web3 = "^0.4.0"

--- a/src/blockchain/ethereum.rs
+++ b/src/blockchain/ethereum.rs
@@ -30,7 +30,12 @@ use web3::Web3;
 pub struct Ethereum {
     web3: Web3<Http>,
     validator: Address,
+    /// The password to unlock the validator account on the node.
     password: String,
+    /// The polling interval defines the duration in between two calls to the node to poll for new
+    /// blocks.
+    polling_interval: Duration,
+    /// A handle to the event loop that runs mosaic.
     event_loop: Box<tokio_core::reactor::Handle>,
 }
 
@@ -44,14 +49,17 @@ impl Ethereum {
     ///
     /// # Arguments
     ///
-    /// * `address` - The address of an ethereum node.
+    /// * `endpoint` - The address of an ethereum node.
     /// * `validator` - The address of the validator to sign and send messages from.
+    /// * `polling_interval` - The duration in between two calls to the node to poll for new blocks.
+    /// * `event_loop` - A handle to the event loop that runs mosaic.
     pub fn new(
-        address: &str,
+        endpoint: &str,
         validator: Address,
+        polling_interval: Duration,
         event_loop: Box<tokio_core::reactor::Handle>,
     ) -> Self {
-        let http = Http::with_event_loop(address, &event_loop, 5)
+        let http = Http::with_event_loop(endpoint, &event_loop, 5)
             .expect("Could not initialize ethereum HTTP connection");
         let web3 = Web3::new(http);
 
@@ -64,6 +72,7 @@ impl Ethereum {
             web3,
             validator,
             password,
+            polling_interval,
             event_loop,
         }
     }
@@ -79,8 +88,9 @@ impl Ethereum {
         let blocks_filter = self.web3.eth_filter().create_blocks_filter();
 
         // Block hashes is a stream of block hashes.
+        let polling_interval = self.polling_interval;
         let block_hashes = blocks_filter
-            .map(|filter| filter.stream(Duration::from_secs(1)))
+            .map(move |filter| filter.stream(polling_interval))
             .flatten_stream();
 
         // Web3 blocks is a stream of block futures, mapped from a stream of block hashes.
@@ -133,13 +143,13 @@ impl Ethereum {
                     ErrorKind::NodeError,
                     format!("Was not able to retrieve accounts: {}", error),
                 )
-            }).and_then(|addresses| {
+            }).map(|addresses| {
                 let mut v = Vec::new();
                 for h160 in addresses {
                     v.push(h160.into())
                 }
 
-                Ok(v)
+                v
             })
     }
 

--- a/src/blockchain/ethereum.rs
+++ b/src/blockchain/ethereum.rs
@@ -14,23 +14,28 @@
 
 //! This module implements the connection to an Ethereum blockchain.
 
+use blockchain::*;
 use rpassword;
-use web3::futures::Future;
-use web3::transports::{EventLoopHandle, Http};
-use web3::types::{H160, H520};
+use std::time::Duration;
+use web3::transports::Http;
+use web3::types::Block as Web3Block;
+use web3::types::H256 as Web3H256;
+use web3::types::U128 as Web3U128;
+use web3::types::U256 as Web3U256;
+use web3::types::{BlockId, H160, H520};
 use web3::Web3;
 
-use blockchain::types::address::{Address, AsAddress, FromAddress};
-use blockchain::types::bytes::Bytes;
-use blockchain::types::error::{Error, ErrorKind};
-use blockchain::types::signature::{AsSignature, Signature};
-
 /// This struct stores a connection to an Ethereum node.
+#[derive(Clone)]
 pub struct Ethereum {
     web3: Web3<Http>,
     validator: Address,
     password: String,
-    _event_loop: EventLoopHandle,
+    event_loop: Box<tokio_core::reactor::Handle>,
+}
+
+trait IntoBlock {
+    fn into_block(&self) -> Result<Block, Error>;
 }
 
 impl Ethereum {
@@ -41,14 +46,13 @@ impl Ethereum {
     ///
     /// * `address` - The address of an ethereum node.
     /// * `validator` - The address of the validator to sign and send messages from.
-    pub fn new(address: &str, validator: Address) -> Result<Self, Error> {
-        let (event_loop, http) = match Http::new(address) {
-            Ok((event_loop, http)) => (event_loop, http),
-            Err(error) => {
-                error!("Could not connect to ethereum: {}", error);
-                return Err(Error::new(ErrorKind::NodeError, error.to_string()));
-            }
-        };
+    pub fn new(
+        address: &str,
+        validator: Address,
+        event_loop: Box<tokio_core::reactor::Handle>,
+    ) -> Self {
+        let http = Http::with_event_loop(address, &event_loop, 5)
+            .expect("Could not initialize ethereum HTTP connection");
         let web3 = Web3::new(http);
 
         let password = rpassword::prompt_password_stdout(&format!(
@@ -56,33 +60,87 @@ impl Ethereum {
             &validator,
         )).unwrap();
 
-        let ethereum = Ethereum {
+        Ethereum {
             web3,
             validator,
             password,
-            _event_loop: event_loop,
-        };
+            event_loop,
+        }
+    }
 
-        ethereum.unlock_account();
+    /// Stream blocks returns a `futures::stream::Stream` of `Block`s.
+    ///
+    /// Converts a stream of web3 blocks to a stream of blocks.
+    ///
+    /// It is the caller's responsibility to poll the stream, e.g. call `for_each` and put the
+    /// future into a reactor.
+    pub fn stream_blocks(&self) -> impl Stream<Item = Block, Error = Error> {
+        // Blocks filter is a future that returns a filter.
+        let blocks_filter = self.web3.eth_filter().create_blocks_filter();
 
-        Ok(ethereum)
+        // Block hashes is a stream of block hashes.
+        let block_hashes = blocks_filter
+            .map(|filter| filter.stream(Duration::from_secs(1)))
+            .flatten_stream();
+
+        // Web3 blocks is a stream of block futures, mapped from a stream of block hashes.
+        let web3_clone = self.web3.clone();
+        let web3_blocks = block_hashes
+            .map_err(|error| {
+                Error::new(
+                    ErrorKind::NodeError,
+                    format!("Error while streaming blocks from node: {}", error),
+                )
+            }).and_then(move |block_hash| {
+                web3_clone
+                    .eth()
+                    .block(BlockId::from(block_hash))
+                    .map_err(|error| {
+                        Error::new(
+                            ErrorKind::NodeError,
+                            format!("Was not able to retrieve block: {}", error),
+                        )
+                    })
+            });
+
+        // Returns a stream of blocks, mapped from a stream of web3 block futures.
+        web3_blocks.and_then(|web3_block| match web3_block {
+            // Mapping web3 block Option to a Block.
+            // Wrapping in Ok() as it has to return an IntoFuture.
+            Some(web3_block) => match web3_block.into_block() {
+                Ok(block) => Ok(block),
+                Err(error) => Err(Error::new(
+                    ErrorKind::NodeError,
+                    format!("Could not convert block from web3: {}", error),
+                )),
+            },
+            None => Err(Error::new(
+                ErrorKind::NodeError,
+                "No block found".to_string(),
+            )),
+        })
     }
 
     /// Uses web3 to retrieve the accounts.
     /// Converts them to blockchain addresses and returns all addresses in a
     /// vector.
-    pub fn get_accounts(&self) -> Vec<Address> {
-        let addresses = self.web3.eth().accounts().wait().unwrap();
-        let mut v = Vec::new();
+    pub fn get_accounts(&self) -> impl Future<Item = Vec<Address>, Error = Error> {
+        self.web3
+            .eth()
+            .accounts()
+            .map_err(|error| {
+                Error::new(
+                    ErrorKind::NodeError,
+                    format!("Was not able to retrieve accounts: {}", error),
+                )
+            }).and_then(|addresses| {
+                let mut v = Vec::new();
+                for h160 in addresses {
+                    v.push(h160.into())
+                }
 
-        for h160 in addresses {
-            match h160.as_address() {
-                Ok(address) => v.push(address),
-                Err(error) => warn!("Unable to convert h160 to address: {}", error),
-            }
-        }
-
-        v
+                Ok(v)
+            })
     }
 
     /// Uses web3 to sign the given data.
@@ -90,70 +148,132 @@ impl Ethereum {
     ///
     /// # Arguments
     ///
-    /// `data` - The data to sign.
+    /// * `data` - The data to sign.
     ///
     /// # Returns
     ///
     /// Returns a `Signature` of the signed data.
-    pub fn sign(&self, data: &Bytes) -> Result<Signature, Error> {
-        let h520 = self
-            .web3
-            .eth()
-            .sign(
-                H160::from_address(&self.validator),
-                web3::types::Bytes(data.bytes()),
-            ).wait()
-            .unwrap();
+    pub fn sign(&self, data: Bytes) -> impl Future<Item = Signature, Error = Error> {
+        let web3_clone = self.web3.clone();
+        let validator = self.validator;
 
-        h520.as_signature()
+        let signature_future = self.unlock_account(None).and_then(move |_| {
+            web3_clone
+                .eth()
+                .sign(validator.into(), web3::types::Bytes(data.bytes().clone()))
+                .map_err(|error| {
+                    Error::new(
+                        ErrorKind::NodeError,
+                        format!("Was not able to sign data: {}", error),
+                    )
+                })
+        });
+
+        signature_future.map(|web3_signature| {
+            let signature: Signature = web3_signature.into();
+            signature
+        })
     }
 
     /// Unlocks the validator account of this ethereum instance using the stored password.
-    /// Unlocks it for the maximum amount of ca. 18 hours.
+    ///
+    /// # Arguments
+    ///
+    /// * `duration` - If given, will unlock for the duration in seconds. Otherwise for a single
+    /// transaction.
     ///
     /// # Panics
     ///
     /// Panics if it cannot unlock the account.
-    fn unlock_account(&self) {
-        let duration: u16 = 65535;
-
-        let unlocked = self
-            .web3
+    fn unlock_account(&self, duration: Option<u16>) -> impl Future<Item = bool, Error = Error> {
+        self.web3
             .personal()
-            .unlock_account(
-                H160::from_address(&self.validator),
-                &self.password,
-                Some(duration),
-            ).wait()
-            .expect("Could not unlock account on ethereum node");
-
-        if unlocked {
-            info!("Unlocked account {:x}", &self.validator);
-        } else {
-            panic!("Could not unlock account {:x}", &self.validator);
-        }
+            .unlock_account(self.validator.into(), &self.password, duration)
+            .map_err(|error| {
+                Error::new(
+                    ErrorKind::NodeError,
+                    format!("Was not able to unlock account: {}", error),
+                )
+            })
     }
 }
 
-impl AsAddress for H160 {
-    /// Converts an H160 type to an Address.
-    /// The address's bytes will be a copy of H160.
-    fn as_address(&self) -> Result<Address, Error> {
-        Address::from_bytes(&self[..])
-    }
-}
-
-impl FromAddress for H160 {
+impl From<Address> for H160 {
     /// Creates an H160 type from an address.
     /// H160 will equal the address's bytes.
-    fn from_address(address: &Address) -> Self {
-        H160::from(address.bytes())
+    fn from(address: Address) -> H160 {
+        let bytes: [u8; 20] = address.into();
+        H160::from(bytes)
     }
 }
 
-impl AsSignature for H520 {
-    fn as_signature(&self) -> Result<Signature, Error> {
-        Signature::from_bytes(&self[..])
+impl From<H160> for Address {
+    /// Converts an H160 type to an Address.
+    /// The address's bytes will be a copy of H160.
+    fn from(h160: H160) -> Address {
+        h160.0.into()
+    }
+}
+
+impl From<Web3H256> for H256 {
+    /// Converts a web3 H256 into an `H256`.
+    fn from(h256: Web3H256) -> H256 {
+        h256.0.into()
+    }
+}
+
+impl From<Web3U128> for U128 {
+    /// Converts a web3 U128 into a `U128`.
+    fn from(u128: Web3U128) -> U128 {
+        u128.0.into()
+    }
+}
+
+impl From<Web3U256> for U256 {
+    /// Converts a web3 U256 into a `U256`.
+    fn from(u256: Web3U256) -> U256 {
+        u256.0.into()
+    }
+}
+
+impl From<H520> for Signature {
+    /// Converts a web3 H520 into a `Signature`.
+    fn from(h520: H520) -> Signature {
+        Signature { 0: h520.0 }
+    }
+}
+
+impl<TX> IntoBlock for Web3Block<TX> {
+    /// Tries to convert a web3 block into a `Block`.
+    ///
+    /// Fails if mandatory fields are missing.
+    fn into_block(&self) -> Result<Block, Error> {
+        Ok(Block {
+            hash: match self.hash {
+                Some(hash) => hash.into(),
+                None => {
+                    return Err(Error::new(
+                        ErrorKind::InvalidBlock,
+                        "Block has no hash".to_string(),
+                    ));
+                }
+            },
+            parent_hash: self.parent_hash.into(),
+            state_root: self.state_root.into(),
+            transactions_root: self.transactions_root.into(),
+            number: match self.number {
+                Some(number) => number.into(),
+                None => {
+                    return Err(Error::new(
+                        ErrorKind::InvalidBlock,
+                        "Block has no number".to_string(),
+                    ))
+                }
+            },
+            gas_used: self.gas_used.into(),
+            gas_limit: self.gas_limit.into(),
+            timestamp: self.timestamp.into(),
+        })
     }
 }
 
@@ -164,62 +284,50 @@ mod test {
     #[test]
     fn test_h160_to_address() {
         let mut bytes = [0u8; 20];
-        assert_eq!(
-            "0000000000000000000000000000000000000000"
-                .parse::<H160>()
-                .unwrap()
-                .as_address()
-                .unwrap(),
-            Address::from_bytes(&bytes[..]).unwrap()
-        );
+        let address: Address = "0000000000000000000000000000000000000000"
+            .parse::<H160>()
+            .unwrap()
+            .into();
+        assert_eq!(address, bytes.into());
 
         bytes[19] = 10u8;
-        assert_eq!(
-            "000000000000000000000000000000000000000a"
-                .parse::<H160>()
-                .unwrap()
-                .as_address()
-                .unwrap(),
-            Address::from_bytes(&bytes[..]).unwrap()
-        );
+        let address: Address = "000000000000000000000000000000000000000a"
+            .parse::<H160>()
+            .unwrap()
+            .into();
+        assert_eq!(address, bytes.into());
 
         bytes[0] = 1u8;
-        assert_eq!(
-            "010000000000000000000000000000000000000a"
-                .parse::<H160>()
-                .unwrap()
-                .as_address()
-                .unwrap(),
-            Address::from_bytes(&bytes[..]).unwrap()
-        );
+        let address: Address = "010000000000000000000000000000000000000a"
+            .parse::<H160>()
+            .unwrap()
+            .into();
+        assert_eq!(address, bytes.into());
     }
 
     #[test]
     fn test_h160_from_address() {
         let mut bytes = [0u8; 20];
+        let address: Address = bytes.into();
+        let h160: H160 = address.into();
         assert_eq!(
-            format!(
-                "{:#?}",
-                H160::from_address(&Address::from_bytes(&bytes[..]).unwrap())
-            ),
+            format!("{:#?}", h160),
             "0x0000000000000000000000000000000000000000"
         );
 
         bytes[19] = 10u8;
+        let address: Address = bytes.into();
+        let h160: H160 = address.into();
         assert_eq!(
-            format!(
-                "{:#?}",
-                H160::from_address(&Address::from_bytes(&bytes[..]).unwrap())
-            ),
+            format!("{:#?}", h160),
             "0x000000000000000000000000000000000000000a"
         );
 
         bytes[0] = 1u8;
+        let address: Address = bytes.into();
+        let h160: H160 = address.into();
         assert_eq!(
-            format!(
-                "{:#?}",
-                H160::from_address(&Address::from_bytes(&bytes[..]).unwrap())
-            ),
+            format!("{:#?}", h160),
             "0x010000000000000000000000000000000000000a"
         );
     }

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -16,6 +16,7 @@
 
 pub use self::types::*;
 use futures::prelude::*;
+use std::time::Duration;
 
 mod ethereum;
 pub mod types;
@@ -38,17 +39,22 @@ impl Blockchain {
     /// * `kind` - The kind that the blockchain shall be.
     /// * `endpoint` - The endpoint of a node of the blockchain.
     /// * `validator` - The address of the validator to sign messages.
+    /// * `polling_interval` - The duration in between two calls to the node to poll for new blocks.
     /// * `event_loop` - The event loop handle.
     pub fn new(
         kind: &BlockchainKind,
         endpoint: &str,
         validator: Address,
+        polling_interval: Duration,
         event_loop: Box<tokio_core::reactor::Handle>,
     ) -> Self {
         match kind {
-            BlockchainKind::Eth => {
-                Blockchain::Eth(ethereum::Ethereum::new(endpoint, validator, event_loop))
-            }
+            BlockchainKind::Eth => Blockchain::Eth(ethereum::Ethereum::new(
+                endpoint,
+                validator,
+                polling_interval,
+                event_loop,
+            )),
         }
     }
 

--- a/src/blockchain/types/basic_types.rs
+++ b/src/blockchain/types/basic_types.rs
@@ -1,0 +1,104 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Basic types are hashes and numbers.
+
+use std::fmt::{self, Formatter, LowerHex};
+
+/// H256 is a 256-bit hash.
+#[derive(Debug)]
+pub struct H256(pub [u8; 32]);
+
+impl H256 {
+    /// Returns the underlying `u8` array.
+    pub fn bytes(&self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl From<[u8; 32]> for H256 {
+    /// Converts a `u8` array of 32 items into an `H256`.
+    fn from(bytes: [u8; 32]) -> Self {
+        Self { 0: bytes }
+    }
+}
+
+impl LowerHex for H256 {
+    /// Writes the bytes as hex with leading zeros to the given Formatter.
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        for byte in self.bytes().iter() {
+            write!(f, "{:02x}", byte)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// U128 is a 128-bit unsigned integer.
+#[derive(Debug)]
+pub struct U128(pub [u64; 2]);
+
+impl U128 {
+    /// Returns the underlying `u64` array.
+    pub fn bytes(&self) -> [u64; 2] {
+        self.0
+    }
+}
+
+impl From<[u64; 2]> for U128 {
+    /// Converts a `u64` array of 2 items into a `U128`.
+    fn from(bytes: [u64; 2]) -> Self {
+        Self { 0: bytes }
+    }
+}
+
+impl LowerHex for U128 {
+    /// Writes the bytes as hex with leading zeros to the given Formatter.
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        for byte in self.bytes().iter() {
+            write!(f, "{:02x}", byte)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// U256 is a 256-bit unsigned integer.
+#[derive(Debug)]
+pub struct U256(pub [u64; 4]);
+
+impl U256 {
+    /// Returns the underlying `u64` array.
+    pub fn bytes(&self) -> [u64; 4] {
+        self.0
+    }
+}
+
+impl From<[u64; 4]> for U256 {
+    /// Converts a `u64` array of 4 items into a `U256`.
+    fn from(bytes: [u64; 4]) -> Self {
+        Self { 0: bytes }
+    }
+}
+
+impl LowerHex for U256 {
+    /// Writes the bytes as hex with leading zeros to the given Formatter.
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        for byte in self.bytes().iter() {
+            write!(f, "{:02x}", byte)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/blockchain/types/block.rs
+++ b/src/blockchain/types/block.rs
@@ -1,0 +1,40 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module covers blocks.
+
+use blockchain::types::basic_types::{H256, U128, U256};
+use std::fmt::{self, Display, Formatter};
+
+/// A block represents a block of a blockchain.
+#[derive(Debug)]
+pub struct Block {
+    /// The block hash of this block. TODO: more?
+    pub hash: H256,
+    pub parent_hash: H256,
+    pub state_root: H256,
+    pub transactions_root: H256,
+    pub number: U128,
+    pub gas_used: U256,
+    pub gas_limit: U256,
+    pub timestamp: U256,
+}
+
+impl Display for Block {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), fmt::Error> {
+        write!(fmt, "Block ({:x})", self.hash);
+
+        Ok(())
+    }
+}

--- a/src/blockchain/types/error.rs
+++ b/src/blockchain/types/error.rs
@@ -14,7 +14,6 @@
 
 //! This module implements the Error struct and its methods.
 
-use std;
 use std::fmt;
 
 /// An Error represents any error that appears during the interaction with a blockchain.
@@ -31,28 +30,21 @@ impl Error {
     }
 }
 
+/// The kinds of errors that can appear.
 #[derive(Debug)]
 pub enum ErrorKind {
     InvalidAddress,
+    InvalidBlock,
     InvalidBytes,
     InvalidSignature,
     NodeError,
-}
-
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        "A blockchain error occurred."
-    }
-
-    fn cause(&self) -> Option<&std::error::Error> {
-        None
-    }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.kind {
             ErrorKind::InvalidAddress => write!(f, "Not a valid address!").unwrap(),
+            ErrorKind::InvalidBlock => write!(f, "Not a valid block!").unwrap(),
             ErrorKind::InvalidBytes => write!(f, "Not valid bytes!").unwrap(),
             ErrorKind::InvalidSignature => write!(f, "Not a valid signature!").unwrap(),
             ErrorKind::NodeError => write!(f, "Error on blockchain node!").unwrap(),

--- a/src/blockchain/types/mod.rs
+++ b/src/blockchain/types/mod.rs
@@ -15,6 +15,15 @@
 //! All the blockchain types that we interact with.
 
 pub mod address;
+pub mod basic_types;
+pub mod block;
 pub mod bytes;
 pub mod error;
 pub mod signature;
+
+pub use self::address::*;
+pub use self::basic_types::*;
+pub use self::block::*;
+pub use self::bytes::*;
+pub use self::error::*;
+pub use self::signature::*;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,7 +14,7 @@
 
 //! This module handles all configuration of this library.
 
-use blockchain::types::address::Address;
+use blockchain::Address;
 use std::env;
 
 // Environment variables and their defaults
@@ -73,7 +73,8 @@ impl Config {
         let origin_core_address =
             match Self::read_environment_variable(ENV_ORIGIN_CORE_ADDRESS, None) {
                 Some(origin_core_address) => Some(
-                    Address::from_string(&origin_core_address)
+                    origin_core_address
+                        .parse::<Address>()
                         .expect("The origin core address cannot be parsed"),
                 ),
                 None => None,
@@ -81,17 +82,17 @@ impl Config {
 
         let origin_validator_address =
             match Self::read_environment_variable(ENV_ORIGIN_VALIDATOR_ADDRESS, None) {
-                Some(origin_validator_address) => Address::from_string(&origin_validator_address)
+                Some(origin_validator_address) => origin_validator_address
+                    .parse::<Address>()
                     .expect("The origin validator address cannot be parsed"),
                 None => panic!("An origin validator address must be set"),
             };
 
         let auxiliary_validator_address =
             match Self::read_environment_variable(ENV_AUXILIARY_VALIDATOR_ADDRESS, None) {
-                Some(auxiliary_validator_address) => {
-                    Address::from_string(&auxiliary_validator_address)
-                        .expect("The auxiliary validator address cannot be parsed")
-                }
+                Some(auxiliary_validator_address) => auxiliary_validator_address
+                    .parse::<Address>()
+                    .expect("The auxiliary validator address cannot be parsed"),
                 None => panic!("An auxiliary validator address must be set"),
             };
 
@@ -150,13 +151,13 @@ impl Config {
     }
 
     /// Returns the origin validator address set on this config.
-    pub fn origin_validator_address(&self) -> &Address {
-        &self.origin_validator_address
+    pub fn origin_validator_address(&self) -> Address {
+        self.origin_validator_address
     }
 
     /// Returns the auxiliary validator address set on this config.
-    pub fn auxiliary_validator_address(&self) -> &Address {
-        &self.auxiliary_validator_address
+    pub fn auxiliary_validator_address(&self) -> Address {
+        self.auxiliary_validator_address
     }
 }
 
@@ -184,12 +185,16 @@ mod test {
             expected_origin_endpoint, config.origin_endpoint,
         );
         assert_eq!(
-            *config.origin_validator_address(),
-            Address::from_string("6789012345678901234567890123456789012345").unwrap()
+            config.origin_validator_address(),
+            "6789012345678901234567890123456789012345"
+                .parse::<Address>()
+                .unwrap()
         );
         assert_eq!(
             config.auxiliary_validator_address(),
-            &Address::from_string("1234567890123456789012345678901234567890").unwrap()
+            "1234567890123456789012345678901234567890"
+                .parse::<Address>()
+                .unwrap()
         );
 
         env::set_var(ENV_ORIGIN_ENDPOINT, "10.0.0.1");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,12 +45,14 @@ pub fn run(config: &Config) -> Result<(), Box<Error>> {
         &BlockchainKind::Eth,
         config.origin_endpoint(),
         config.origin_validator_address(),
+        config.origin_polling_interval(),
         Box::new(event_loop.handle()),
     );
     let auxiliary = Blockchain::new(
         &BlockchainKind::Eth,
         config.auxiliary_endpoint(),
         config.auxiliary_validator_address(),
+        config.auxiliary_polling_interval(),
         Box::new(event_loop.handle()),
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ use mosaic::Config;
 use std::env;
 use std::process;
 
+const ERROR_MOSAIC: i32 = 1;
+
 const ENV_LOG_LEVEL: &str = "MOSAIC_LOG_LEVEL";
 const DEFAULT_LOG_LEVEL: Level = Level::Info;
 
@@ -33,8 +35,8 @@ fn main() {
     let config = Config::new();
 
     if let Err(e) = mosaic::run(&config) {
-        error!("Application error: {}", e);
-        process::exit(1);
+        error!("Mosaic error: {}", e);
+        process::exit(ERROR_MOSAIC);
     }
 }
 

--- a/src/observer/mod.rs
+++ b/src/observer/mod.rs
@@ -1,0 +1,68 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module is about observing blockchains.
+
+use super::blockchain::Blockchain;
+use futures::prelude::*;
+
+/// Runs a mosaic observer. The observer observes blocks from origin and auxiliary. When a new block
+/// is observed, the observer hands new  tasks to the reactor, based on the block origin and
+/// content.
+///
+/// Observations are handled as streams that are added to the given event loop.
+///
+/// # Arguments
+///
+/// * `origin` - A blockchain object that points to origin.
+/// * `auxiliary` - A blockchain object that points to auxiliary.
+/// * `event_loop` - The reactor's event loop to handle the tasks spawned by this observer.
+pub fn run(origin: &Blockchain, auxiliary: &Blockchain, event_loop: &tokio_core::reactor::Handle) {
+    let origin_stream = origin.stream_blocks();
+    let auxiliary_stream = auxiliary.stream_blocks();
+
+    // `info!`s are just used as an example. The actual logic of how to handle each block will be
+    // done here. Should spawn new futures to not block if longer computation.
+    let origin_worker = origin_stream.map_err(|_| ()).for_each(|block| {
+        info!("Origin Block:    {}", block);
+        Ok(())
+    });
+    let auxiliary_worker = auxiliary_stream.map_err(|_| ()).for_each(|block| {
+        info!("Auxiliary Block: {}", block);
+        Ok(())
+    });
+
+    event_loop.spawn(origin_worker);
+    event_loop.spawn(auxiliary_worker);
+
+    // Below here is only example code to see how it works:
+    let signature = origin.sign(vec![1, 2, 3, 4].into());
+    event_loop.spawn(
+        signature
+            .map_err(|error| error!("Could not sign in observer: {}", error))
+            .and_then(|signature| {
+                info!("Signature: {:x}", signature);
+                Ok(())
+            }),
+    );
+
+    let accounts = origin
+        .get_accounts()
+        .map_err(|error| error!("Could not get accounts: {}", error))
+        .and_then(|accounts| {
+            info!("Received accounts: {:?}", accounts);
+            Ok(())
+        });
+    event_loop.spawn(accounts);
+}


### PR DESCRIPTION
A new observer module will handle all observations of both chains. Right
now it only contains placeholder code.
A blockchain now provides a method that returns a stream of blocks. This
stream is used by the observer to act upon new blocks.

In the vein of idiomatic rust, alot of `IntoX` and `FromX` custom traits
were replaced with the std `From` trait.

Fixes #16