### PR TITLE
Blocks stream now includes events

### DIFF
--- a/src/blockchain/types/basic_types.rs
+++ b/src/blockchain/types/basic_types.rs
@@ -13,17 +13,27 @@
 // limitations under the License.
 
 //! Basic types are hashes and numbers.
+//!
+//! Most big numbers are represented as arrays of primitive types. For example, `U128` is
+//! represented as [u64; 2]. In that case, the `0` index of the array is the lower numbers and the
+//! `1` index is the higher numbers. This means a decimal `1` would be represented as `[1, 0]`.
 
 use std::fmt::{self, Formatter, LowerHex};
 
 /// H256 is a 256-bit hash.
-#[derive(Debug)]
+#[derive(Debug, Copy, PartialEq)]
 pub struct H256(pub [u8; 32]);
 
 impl H256 {
     /// Returns the underlying `u8` array.
     pub fn bytes(&self) -> [u8; 32] {
         self.0
+    }
+}
+
+impl Clone for H256 {
+    fn clone(&self) -> H256 {
+        *self
     }
 }
 
@@ -46,7 +56,7 @@ impl LowerHex for H256 {
 }
 
 /// U128 is a 128-bit unsigned integer.
-#[derive(Debug)]
+#[derive(Debug, Copy, PartialEq)]
 pub struct U128(pub [u64; 2]);
 
 impl U128 {
@@ -56,10 +66,27 @@ impl U128 {
     }
 }
 
+impl Clone for U128 {
+    fn clone(&self) -> U128 {
+        *self
+    }
+}
+
 impl From<[u64; 2]> for U128 {
     /// Converts a `u64` array of 2 items into a `U128`.
     fn from(bytes: [u64; 2]) -> Self {
         Self { 0: bytes }
+    }
+}
+
+impl From<U128> for u64 {
+    /// Tries to convert a U128 to a u64. Panics on overflow.
+    fn from(u128: U128) -> u64 {
+        if u128.0[1] != 0 {
+            panic!("Overflow when converting U128 to u64.");
+        }
+
+        u128.0[0]
     }
 }
 
@@ -75,13 +102,19 @@ impl LowerHex for U128 {
 }
 
 /// U256 is a 256-bit unsigned integer.
-#[derive(Debug)]
+#[derive(Debug, Copy, PartialEq)]
 pub struct U256(pub [u64; 4]);
 
 impl U256 {
     /// Returns the underlying `u64` array.
     pub fn bytes(&self) -> [u64; 4] {
         self.0
+    }
+}
+
+impl Clone for U256 {
+    fn clone(&self) -> U256 {
+        *self
     }
 }
 

--- a/src/blockchain/types/block.rs
+++ b/src/blockchain/types/block.rs
@@ -14,13 +14,13 @@
 
 //! This module covers blocks.
 
-use blockchain::types::basic_types::{H256, U128, U256};
+use blockchain::types::{Address, Bytes, H256, U128, U256};
 use std::fmt::{self, Display, Formatter};
 
 /// A block represents a block of a blockchain.
 #[derive(Debug)]
 pub struct Block {
-    /// The block hash of this block. TODO: more?
+    /// The block hash of this block.
     pub hash: H256,
     pub parent_hash: H256,
     pub state_root: H256,
@@ -29,6 +29,7 @@ pub struct Block {
     pub gas_used: U256,
     pub gas_limit: U256,
     pub timestamp: U256,
+    pub events: Vec<Event>,
 }
 
 impl Display for Block {
@@ -37,4 +38,18 @@ impl Display for Block {
 
         Ok(())
     }
+}
+#[derive(Debug, Clone, PartialEq)]
+pub struct Event {
+    pub address: Address,
+    pub topics: Vec<H256>,
+    pub data: Bytes,
+    pub block_hash: Option<H256>,
+    pub block_number: Option<U256>,
+    pub transaction_hash: Option<H256>,
+    pub transaction_index: Option<U256>,
+    pub log_index: Option<U256>,
+    pub transaction_log_index: Option<U256>,
+    pub log_type: Option<String>,
+    pub removed: Option<bool>,
 }

--- a/src/blockchain/types/error.rs
+++ b/src/blockchain/types/error.rs
@@ -38,6 +38,7 @@ pub enum ErrorKind {
     InvalidBytes,
     InvalidSignature,
     NodeError,
+    Overflow,
 }
 
 impl fmt::Display for Error {
@@ -48,6 +49,7 @@ impl fmt::Display for Error {
             ErrorKind::InvalidBytes => write!(f, "Not valid bytes!").unwrap(),
             ErrorKind::InvalidSignature => write!(f, "Not a valid signature!").unwrap(),
             ErrorKind::NodeError => write!(f, "Error on blockchain node!").unwrap(),
+            ErrorKind::Overflow => write!(f, "Overflow!").unwrap(),
         };
 
         write!(f, " Explanation: {}", self.explanation).unwrap();

--- a/src/observer/mod.rs
+++ b/src/observer/mod.rs
@@ -32,16 +32,49 @@ pub fn run(origin: &Blockchain, auxiliary: &Blockchain, event_loop: &tokio_core:
     let origin_stream = origin.stream_blocks();
     let auxiliary_stream = auxiliary.stream_blocks();
 
-    // `info!`s are just used as an example. The actual logic of how to handle each block will be
-    // done here. Should spawn new futures to not block if longer computation.
-    let origin_worker = origin_stream.map_err(|_| ()).for_each(|block| {
-        info!("Origin Block:    {}", block);
-        Ok(())
-    });
-    let auxiliary_worker = auxiliary_stream.map_err(|_| ()).for_each(|block| {
-        info!("Auxiliary Block: {}", block);
-        Ok(())
-    });
+    // Using `then` to catch errors. If the errors weren't caught, the stream would terminate after
+    // an error. However, we want to continue polling the node for new blocks, even if there was an
+    // error with a particular block. In the `for_each` block we need to then check for an existing
+    // block as we caught all blocks and errors and mapped both to `Option`al blocks (`None` in the
+    // error case).
+    let origin_worker = origin_stream
+        .then(|item| match item {
+            Ok(block) => Ok(Some(block)),
+            Err(error) => {
+                error!("Error when streaming from origin chain: {}", error);
+                Ok(None)
+            }
+        }).for_each(|block| {
+            let block = match block {
+                Some(block) => block,
+                None => return Ok(()),
+            };
+
+            // `info!`s are just used as an example. The actual logic of how to handle each block will be
+            // done here. Should spawn new futures to not block if longer computation.
+            info!("Origin Block:     {}", block);
+            info!("Origin Events:    {:?}", block.events);
+
+            Ok(())
+        });
+
+    let auxiliary_worker = auxiliary_stream
+        .then(|item| match item {
+            Ok(block) => Ok(Some(block)),
+            Err(error) => {
+                error!("Error when streaming from auxiliary chain: {}", error);
+                Ok(None)
+            }
+        }).for_each(|block| {
+            let block = match block {
+                Some(block) => block,
+                None => return Ok(()),
+            };
+
+            info!("Auxiliary Block:  {}", block);
+            info!("Auxiliary Events: {:?}", block.events);
+            Ok(())
+        });
 
     event_loop.spawn(origin_worker);
     event_loop.spawn(auxiliary_worker);


### PR DESCRIPTION
For each block, it now also gets the events and adds them to the
`events` field of the `Block` struct as part of the stream pipeline.

I also fixed an issue where the stream wolud yield an error. Before, the
stream would terminate after the error. Now, the error is printed, but
the stream continues polling the node.
I had the error that sometimes the block could not be retrieved when
ganache rolled back to a previous snapshot.

Ref. #18 #35